### PR TITLE
Notes on PresentationController.php

### DIFF
--- a/app/Http/Controllers/PresentationsController.php
+++ b/app/Http/Controllers/PresentationsController.php
@@ -45,6 +45,7 @@ class PresentationsController extends Controller
      */
     public function create(){
         $presentation = new Presentation();
+        // may be problematic
         $presentation->type = -1;
         $presentation->course = null;
         $presentation = $this->setOwner($presentation);
@@ -152,6 +153,7 @@ class PresentationsController extends Controller
 
     public function save_comment($id, Request $request){
         $comments=$request->all();
+        // This should be wrapped in a try...catch
         $presentation= Presentation::findOrFail($id);
         $presentation->status='D';
         $presentation->comments=$comments['comments'];
@@ -168,6 +170,7 @@ class PresentationsController extends Controller
     private function prepare_form($presentation, $action){
         $user = Auth::user();
 
+        // extra call
         if(Auth::user()->is_professor())
             $courses = $user->courses;
         else
@@ -179,6 +182,7 @@ class PresentationsController extends Controller
     }
 
 
+    /* Problems */
     private function setOwner($presentation){
         $user = Auth::user();
 


### PR DESCRIPTION
You're calling `findOrFail()`, but not handling the situation of it failing.  Those calls should be wrapped in a try...catch() and methods should be restructured to handle a failure.  Same applies to elsewhere in this class that uses `findOrFail()`.

You also need to handle the situation of a save() or delete() or other database action failing.  Just a simple `flash()->error()` would suffice.

**index()**
Calling `array_unshift()` like that is fine as long as the PresentationType records start at ID 1, and are consecutive. What happens when/if a PresentationType gets deleted, then another one added? The auto-increment index doesn't get reset on deletion, so the new PresentationType record will get the next auto-increment value. In this situation, you could have PresentationType records with ids 1-9, and 11. The position in the array for the last record will no longer match the ID.

I suggest not using the array index as a substitute for the ID, and just pull the ID out of the PresentationType object in your view.

**create()**
`$presentation->type` and `$presentation->course` are both initialized to impossible values - which is good.  However, they use different impossible values.  While that will work, it may be a little tricky elsewhere if you're testing for a value and are unsure if you should check against NULL or against -1.  I think it's best to use only NULL for fields that don't have a valid value.


**prepare_form()**
You're assigning `Auth::user()` to `$user`, but not using `$user` anywhere.

**setOwner() is problematic for a few reasons.**
1) You're setting the owner, which is a user id, but you're passing it a Presentation object.  This method then has to pull apart a Presentation object to get at what it needs.  A better plan would be to just have `setOwner()` accept a user id directly.  This will allow you to use this method even in situations where you don't already have a Presentation object

2) Not only are you setting the owner id, you're also setting 1 of 2 name fields.  This is called a "side-effect" and is a bugger when trying to debug.  "`setOwner()`" implies the owner will be set - it's not obvious that the name will also be set.  You should create a separate method for setting the name.  Yes, it will create another method call, but there won't be any hidden consequences to the method calls.

3) The fact that it's a method of the Presentation class, but operates on a passed Presentation object is weird.  Why not just make it act on the current Presentation object?  So rather than calling `$presentation = $this->setOwner($presentation)`, you could call `$presentation->setOwner($owner_id)`  You would have to make `setOwner()` public, but that's no big deal.

4) This is a stylistic issue, but you've named this method with camel-case, but the other multi-word methods are words separated with underscores.  Best practice is to pick one or the other.