### PR TITLE
Notes on RolesController.php

### DIFF
--- a/app/Http/Controllers/RolesController.php
+++ b/app/Http/Controllers/RolesController.php
@@ -15,6 +15,7 @@ class RolesController extends Controller
         $this->middleware('admin', ['except' => 'new_role']);
     }
 
+    // Authorized()
     public function index(){
         $users = User::where('requested_new_role', true)->get();
         return view('roles.index')->with('users', $users);


### PR DESCRIPTION
**findOrFail()**
See notes on PresentationController.php

**index()**
Shouldn't access to this method be restricted?  A list of all users and their roles is definitely privileged information.  Maybe it is and I just don't understand Laravel.  

**new_role() and approve()**
It's not clear from the method names that these two methods turn someone into a professor.  I would recommend renaming these to: `requestProfessorRole()` and `approveProfessorRole()`

**modify()** 
should handle `save()` failing.